### PR TITLE
remove a repeated method

### DIFF
--- a/src/swapsort_17to25.jl
+++ b/src/swapsort_17to25.jl
@@ -130,7 +130,6 @@ function swapsort(a::T, b::T, c::T, d::T, e::T,
     return a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q
 end
 
-@inline swapsort(x::NTuple{17,T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
 @inline swapsort(::Type{Val{17}}, x::AbstractVector{T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
 
 #    sort 18 values with 82 minmaxs in 13 parallel stages


### PR DESCRIPTION
```
julia> using SortingNetworks
Precompiling SortingNetworks
        Info Given IntervalSets was explicitly requested, output will be shown live
WARNING: Method definition swapsort(NTuple{17, T}) where {T} in module SortingNetworks at C:\Users\***\.julia\packages\SortingNetworks\qxn4S\src\swapsort_17to25.jl:27 overwritten at C:\Users\***\.julia\packages\SortingNetworks\qxn4S\src\swapsort_17to25.jl:133.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
```