### PR TITLE
fix method overwrite warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "07e3d4f1-5dc2-5a3a-9c19-e1965b76eff9"
 repo = "https://github.com/JeffreySarnoff/SortingNetworks.jl.git"
 author = "Jeffrey Sarnoff"
 license = "MIT"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/swapsort_17to25.jl
+++ b/src/swapsort_17to25.jl
@@ -16,12 +16,15 @@
         http://search.cpan.org/dist/Algorithm-Networksort/
 =#
 
-const MORE_ARGS_MIN = 17
+const MORE_ARGS_MIN = 18
 const MORE_ARGS_MAX = 25
 
 #=
    sort NTuples of 17..25 values
 =#
+
+@inline swapsort(x::NTuple{17,T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
+@inline swapsort(::Type{Val{17}}, x::AbstractVector{T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
 
 for N in collect(MORE_ARGS_MIN:MORE_ARGS_MAX)
     @eval swapsort(x::NTuple{$N, T}) where T = swapsort(x...)
@@ -129,9 +132,6 @@ function swapsort(a::T, b::T, c::T, d::T, e::T,
 
     return a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q
 end
-
-@inline swapsort(x::NTuple{17,T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
-@inline swapsort(::Type{Val{17}}, x::AbstractVector{T}) where {T} = swapsort(x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11], x[12], x[13], x[14], x[15], x[16], x[17])
 
 #    sort 18 values with 82 minmaxs in 13 parallel stages
 


### PR DESCRIPTION
Fixes the following:
```julia
julia> using SortingNetworks
Precompiling SortingNetworks
        Info Given SortingNetworks was explicitly requested, output will be shown live 
WARNING: Method definition swapsort(NTuple{17, T}) where {T} in module SortingNetworks at /home/jan/
.julia/dev/SortingNetworks/src/swapsort_17to25.jl:26 overwritten at /home/jan/.julia/dev/SortingNetw
orks/src/swapsort_17to25.jl:30.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)`
 to opt-out of precompilation.
  ? SortingNetworks
[ Info: Precompiling SortingNetworks [07e3d4f1-5dc2-5a3a-9c19-e1965b76eff9]
WARNING: Method definition swapsort(NTuple{17, T}) where {T} in module SortingNetworks at /home/jan/
.julia/dev/SortingNetworks/src/swapsort_17to25.jl:26 overwritten at /home/jan/.julia/dev/SortingNetw
orks/src/swapsort_17to25.jl:30.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)`
 to opt-out of precompilation.
[ Info: Skipping precompilation since __precompile__(false). Importing SortingNetworks [07e3d4f1-5dc
2-5a3a-9c19-e1965b76eff9].
```